### PR TITLE
Dev 1481 handle fields with keyword name

### DIFF
--- a/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
+++ b/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
@@ -121,6 +121,11 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
     val propNames = c.properties.map(p => '"' + p.name + '"').mkString(", ")
     val className = c.identifier
 
+    // Special use case:
+    // When the class name contains reserved keywords, for example type, class, then the generated scala case class field name will be prefixed with an underscore
+    // In this case only the casecodecs
+    val useCaseCodec = c.properties.map(_.name).exists(reservedKeywords.contains)
+
     c.additionalNested match {
       case None =>
         s"""implicit def ${className}Codec = CodecJson.derived(EncodeJson.of[$className], DecodeJson.of[$className])"""

--- a/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
+++ b/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
@@ -126,7 +126,6 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
         s"""implicit def ${className}Codec = CodecJson.derived(EncodeJson.of[$className], DecodeJson.of[$className])"""
       case Some(additionalType) =>
         val addClassReference = genPropertyType(additionalType)
-        val addPropNames      = propNames + (propNames.isEmpty ? "" | ", ") + '"' + addPropName + '"'
         s"""
            implicit def ${className}Codec = CodecJson.derived(EncodeJson[$className] {
               v =>

--- a/codegen/src/main/scala/json/schema/codegen/package.scala
+++ b/codegen/src/main/scala/json/schema/codegen/package.scala
@@ -156,7 +156,7 @@ package object codegen {
         }.toList.sequenceU
         codecFiles <- modelsToGenerate.map {
           case (packageName, packageModels) =>
-            generateCodecFiles(packageModels, packageName, codeGenTarget).withDebug("serializatoin files")
+            generateCodecFiles(packageModels, packageName, codeGenTarget).withDebug("serialization files")
         }.toList.sequenceU
         predefinedCodecs <- generateCodecFiles(codeGenTarget).withDebug("serialization files")
       } yield {

--- a/codegen/src/test/scala/json/schema/codegen/CodecTest.scala
+++ b/codegen/src/test/scala/json/schema/codegen/CodecTest.scala
@@ -1,0 +1,43 @@
+package json.schema.codegen
+
+import argonaut.Argonaut._
+import argonaut.{CodecJson, DecodeResult, HCursor}
+import org.scalatest.{FlatSpec, Matchers}
+
+class CodecTest extends FlatSpec with Matchers {
+
+  "Argonaut" should "encode/decode fields having a scala keyword name" in {
+
+    object Mime extends Enumeration {
+      val text = Value("text")
+      val file = Value("file")
+    }
+
+    implicit val mimeCodec: CodecJson[Mime.Value] =
+      CodecJson[Mime.Value](
+        (v: Mime.Value) => v.toString.asJson,
+        (j: HCursor) =>
+          j.as[String].flatMap { s: String =>
+            try DecodeResult.ok(Mime.withName(s))
+            catch {
+              case _: NoSuchElementException => DecodeResult.fail("_type", j.history)
+            }
+          }
+      )
+
+    case class SpecialFields(_type: Mime.Value, message: String)
+
+    // when want to encode/decode based on types only and eventually different fields names, use case codecs
+    implicit val testCodec = CodecJson.casecodec2(SpecialFields.apply, SpecialFields.unapply)("type", "message")
+
+    // when want to encode/decode based on field names and types use derived option
+    //import ArgonautShapeless._
+    //implicit val testCodec = CodecJson.derived(EncodeJson.of[SpecialFields], DecodeJson.of[SpecialFields])
+
+    val input   = "{\"type\":\"text\",\"message\":\"aloha\"}"
+    val payload = input.decodeOption[SpecialFields].getOrElse(sys.error("unable to decode"))
+
+    payload._type shouldBe Mime.text
+    payload.message shouldBe "aloha"
+  }
+}

--- a/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
+++ b/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
@@ -1,0 +1,47 @@
+package json.schema.codegen
+
+import json.schema.parser.JsonSchemaParser
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+
+class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator with ConsoleLogging {
+
+  def parse(s: String): SValidation[Set[LangType]] = JsonSchemaParser.parse(s).flatMap(ScalaModelGenerator(_))
+
+  def gen(s: String): SValidation[String] =
+    parse(s).map { ts =>
+      ts.map {
+        case t: ClassType => genCodecClass(t)
+        case _ => ""
+      }.filter(_.nonEmpty).mkString("\n")
+    }
+
+  it should "generate codec with case classes when field name is scala keyword" in {
+    val codec = gen(
+      """
+        |{
+        | "id": "http://some/product",
+        |"type":"object",
+        |"properties": {
+        |"type":{"type":"string"},
+        |"b":{"type":"number"}
+        |},
+        |"required":["type"]
+        |}
+      """.stripMargin)
+    println(codec)
+    // TODO: continue from here
+
+    //shouldBe \/-("""case class Product(_type:String, b:Option[Double])""".stripMargin.trim)
+    gen(
+      """
+        |{
+        | "id": "http://some/product",
+        |"type":"object",
+        |"properties": {
+        |"big number":{"type":"number"}
+        |}
+        |}
+      """.stripMargin) shouldBe \/-("""case class Product(big_number:Option[Double])""".stripMargin.trim)
+  }
+}

--- a/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
+++ b/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
@@ -16,7 +16,7 @@ class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator
       }.filter(_.nonEmpty).mkString("\n")
     }
 
-  it should "generate codec with case classes when field name is scala keyword" in {
+  it should "generate case codec implicits when field name is scala keyword" in {
     val codec = gen(
       """
         |{
@@ -29,19 +29,22 @@ class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator
         |"required":["type"]
         |}
       """.stripMargin)
-    println(codec)
-    // TODO: continue from here
+    codec shouldBe \/-("""implicit def ProductCodec = casecodec2(Product.apply, Product.unapply)("type", "b")""".stripMargin.trim)
+  }
 
-    //shouldBe \/-("""case class Product(_type:String, b:Option[Double])""".stripMargin.trim)
-    gen(
+  it should "generate derived codec implicits when field name is not a scala keyword" in {
+    val codec = gen(
       """
         |{
         | "id": "http://some/product",
         |"type":"object",
         |"properties": {
-        |"big number":{"type":"number"}
+        |"notKeyword":{"type":"string"},
+        |"b":{"type":"number"}
+        |},
+        |"required":["type"]
         |}
-        |}
-      """.stripMargin) shouldBe \/-("""case class Product(big_number:Option[Double])""".stripMargin.trim)
+      """.stripMargin)
+    codec shouldBe \/-("""implicit def ProductCodec = CodecJson.derived(EncodeJson.of[Product], DecodeJson.of[Product])""".stripMargin.trim)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.6"
+version in ThisBuild := "0.8.7-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.6-SNAPSHOT"
+version in ThisBuild := "0.8.6"


### PR DESCRIPTION
Fall back to case codecs if the json schema field names having reserved keywords, such as `type`