### PR TITLE
Dev 1514 adaptive codec generation

### DIFF
--- a/codegen/build.sbt
+++ b/codegen/build.sbt
@@ -1,7 +1,7 @@
 scalaVersion := "2.12.4"
 
 libraryDependencies ++= Seq(
-  "com.voxsupplychain" %% "json-schema-parser" % "0.13.0",
+  "com.voxsupplychain" %% "json-schema-parser" % "0.13.1",
   "org.scalacheck"     %% "scalacheck"         % "1.13.4",
   "org.scalatest"      %% "scalatest"          % "3.0.1"
 )

--- a/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
+++ b/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
@@ -133,9 +133,8 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
         s"unable to generate codecs for field names ${reservedNames.mkString(",")}, please rename it to a non Scala keyword"
       )
     }
-    if (hasMoreThan22Fields) {
+    if (hasMoreThan22Fields)
       info(s"using derived codecs for $className ...")
-    }
     val useCaseCodec = !hasMoreThan22Fields
     c.additionalNested match {
       case None =>
@@ -143,12 +142,13 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
           s"casecodec${c.properties.length}($className.apply, $className.unapply)($propNames)",
           s"CodecJson.derived(EncodeJson.of[$className], DecodeJson.of[$className])"
         )
-        s"""implicit def ${className}Codec = $codecStatement"""
+        s"""implicit def ${className}Codec = $codecStatement""".stripMargin
       case Some(additionalType) =>
         val addClassReference = genPropertyType(additionalType)
+        val addPropNames      = propNames + (propNames.isEmpty ? "" | ", ") + '"' + addPropName + '"'
         useCaseCodec.fold(
           s"""
-           private def ${className}SimpleCodec: CodecJson[$className] = CodecJson.derived(EncodeJson.of[$className], DecodeJson.of[$className])
+           private def ${className}SimpleCodec: CodecJson[$className] = casecodec${c.properties.length + 1}($className.apply, $className.unapply)($addPropNames)
 
            implicit def ${className}Codec: CodecJson[$className] = CodecJson.derived(EncodeJson {
               v =>

--- a/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
+++ b/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
@@ -11,7 +11,7 @@ class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator
   def gen(s: String): SValidation[String] =
     parse(s).map { ts =>
       ts.map {
-        case t: ClassType => genCodecClass(t)
+        case t: ClassType => genCodecClass(t).trim
         case _ => ""
       }.filter(_.nonEmpty).mkString("\n")
     }
@@ -106,5 +106,39 @@ class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator
         |"required":["b0"]
         |}
       """.stripMargin)
+  }
+
+  it should "generate codecs type with additional properties in a map" in {
+    gen("""
+          |{
+          | "id": "http://some/product",
+          |"type":"object",
+          |"additionalProperties":{"$ref":"#/definitions/nested"},
+          |"definitions": {
+          |"nested": {
+          |"id":"#/definitions/nested",
+          |"type":"object"
+          | }
+          |}
+          |}
+      """.stripMargin) shouldBe
+      \/-("""private def ProductSimpleCodec: CodecJson[Product] = casecodec1(Product.apply, Product.unapply)("_additional")
+            |
+            |           implicit def ProductCodec: CodecJson[Product] = CodecJson.derived(EncodeJson {
+            |              v =>
+            |                val j = ProductSimpleCodec.encode(v)
+            |                val nj = j.field("_additional").fold(j)(a => j.deepmerge(a))
+            |                nj.hcursor.downField("_additional").deleteGoParent.focus.getOrElse(nj)
+            |            }, DecodeJson {
+            |              c =>
+            |                val md: DecodeJson[Option[Map[String, product.definitions.Nested]]] = implicitly
+            |                val od: DecodeJson[Product] = ProductSimpleCodec
+            |                for {
+            |                  o <- od.decode(c)
+            |                  withoutProps = List().foldLeft(c)((c, f) => c.downField(f).deleteGoParent.hcursor.getOrElse(c))
+            |                  m <- md.decode(withoutProps)
+            |                } yield o.copy(_additional = m)
+            |            })
+            |implicit def NestedCodec = casecodec0(Nested.apply, Nested.unapply)()""".stripMargin)
   }
 }

--- a/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
+++ b/codegen/src/test/scala/json/schema/codegen/ScalaCodecGeneratorTest.scala
@@ -16,7 +16,7 @@ class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator
       }.filter(_.nonEmpty).mkString("\n")
     }
 
-  it should "generate case codec implicits when field name is scala keyword" in {
+  it should "generate case codec implicits when are less than 22 fields" in {
     val codec = gen(
       """
         |{
@@ -32,19 +32,79 @@ class ScalaCodecGeneratorTest extends FlatSpec with Matchers with ScalaGenerator
     codec shouldBe \/-("""implicit def ProductCodec = casecodec2(Product.apply, Product.unapply)("type", "b")""".stripMargin.trim)
   }
 
-  it should "generate derived codec implicits when field name is not a scala keyword" in {
+  it should "generate derived codec implicits when are more than 22 fields" in {
     val codec = gen(
       """
         |{
         | "id": "http://some/product",
         |"type":"object",
         |"properties": {
-        |"notKeyword":{"type":"string"},
-        |"b":{"type":"number"}
+        |"b0":{"type":"number"},
+        |"b1":{"type":"number"},
+        |"b2":{"type":"number"},
+        |"b3":{"type":"number"},
+        |"b4":{"type":"number"},
+        |"b5":{"type":"number"},
+        |"b6":{"type":"number"},
+        |"b7":{"type":"number"},
+        |"b8":{"type":"number"},
+        |"b9":{"type":"number"},
+        |"b10":{"type":"number"},
+        |"b11":{"type":"number"},
+        |"b12":{"type":"number"},
+        |"b13":{"type":"number"},
+        |"b14":{"type":"number"},
+        |"b15":{"type":"number"},
+        |"b16":{"type":"number"},
+        |"b17":{"type":"number"},
+        |"b18":{"type":"number"},
+        |"b19":{"type":"number"},
+        |"b20":{"type":"number"},
+        |"b21":{"type":"number"},
+        |"b22":{"type":"number"},
+        |"b23":{"type":"number"}
         |},
-        |"required":["type"]
+        |"required":["b0"]
         |}
       """.stripMargin)
     codec shouldBe \/-("""implicit def ProductCodec = CodecJson.derived(EncodeJson.of[Product], DecodeJson.of[Product])""".stripMargin.trim)
+  }
+
+  it should "fail to generate derived codec implicits when are more than 22 fields and a field name is a scala keyword" in {
+    an[IllegalArgumentException] should be thrownBy gen(
+      """
+        |{
+        | "id": "http://some/product",
+        |"type":"object",
+        |"properties": {
+        |"type":{"type":"string"},
+        |"b0":{"type":"number"},
+        |"b1":{"type":"number"},
+        |"b2":{"type":"number"},
+        |"b3":{"type":"number"},
+        |"b4":{"type":"number"},
+        |"b5":{"type":"number"},
+        |"b6":{"type":"number"},
+        |"b7":{"type":"number"},
+        |"b8":{"type":"number"},
+        |"b9":{"type":"number"},
+        |"b10":{"type":"number"},
+        |"b11":{"type":"number"},
+        |"b12":{"type":"number"},
+        |"b13":{"type":"number"},
+        |"b14":{"type":"number"},
+        |"b15":{"type":"number"},
+        |"b16":{"type":"number"},
+        |"b17":{"type":"number"},
+        |"b18":{"type":"number"},
+        |"b19":{"type":"number"},
+        |"b20":{"type":"number"},
+        |"b21":{"type":"number"},
+        |"b22":{"type":"number"},
+        |"b23":{"type":"number"}
+        |},
+        |"required":["b0"]
+        |}
+      """.stripMargin)
   }
 }

--- a/examples/project/plugins.sbt
+++ b/examples/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.voxsupplychain" %% "json-schema-codegen-sbt" % "0.7.2-SNAPSHOT")
+addSbtPlugin("com.voxsupplychain" %% "json-schema-codegen-sbt" % "0.8.7-SNAPSHOT")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.7"
+version in ThisBuild := "0.8.8-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.8"
+version in ThisBuild := "0.8.9-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.7-SNAPSHOT"
+version in ThisBuild := "0.8.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.8-SNAPSHOT"
+version in ThisBuild := "0.8.8"


### PR DESCRIPTION
Added adaptive codecs generation. Using only derived codecs slows down the build from 4-5 mins to 13-15 minutes, mainly because of the macros.
For structures having less than 23 properties, it falls back to case codec generation.
Added tests for codec generation, we had no tests for that functionality.