### PR TITLE
Gmv 288 codec json handle wrong uri format

### DIFF
--- a/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
+++ b/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
@@ -38,6 +38,7 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
           import argonaut._, Argonaut._, ArgonautShapeless._
           import java.time.format.DateTimeFormatter
           import java.time.ZoneId
+          import java.net.URISyntaxException
 
           trait $codecClassName {
             $codecs
@@ -239,6 +240,7 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
                   DecodeResult.ok(new java.net.URI(uri))
                 } catch {
                   case e:NoSuchElementException => DecodeResult.fail("URI", j.history)
+                  case e:URISyntaxException  => DecodeResult.fail("URI syntax", j.history)
                 }
               }
             )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.17"
+version in ThisBuild := "0.8.18-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.16-SNAPSHOT"
+version in ThisBuild := "0.8.17"


### PR DESCRIPTION
At Product creation time, when the client provides a wrong URL in the videoUrls field.
The CodecJson type class instance for java.net.URI is not handling the URISyntaxException allowing the exception to bubble up and not being mapped into a `ErrorResponse` [ControllerValidation.scala](https://github.com/tundracom/buy/blob/88e1dc87a5ab44be65337c1fc1f691ed0c9fc284/services/buy/web/src/main/scala/vox/buy/controller/common/ControllerValidation.scala#L113-L114)

I propose to handle that exception and turn it into a failed DecodeResult.



Linked to: https://tundradotcom.atlassian.net/browse/GMV-288