### PR TITLE
Force to serialize the OffsetDateTime with milliseconds

### DIFF
--- a/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
+++ b/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
@@ -249,7 +249,7 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
 
   def genCodecDateTime(): String =
     s"""
-    val IsoOffsetDateTimeWithMilliseconds = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+    val IsoOffsetDateTimeWithMilliseconds = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 
     implicit def DateTimeCodec: CodecJson[java.time.OffsetDateTime] =
       CodecJson.derived(

--- a/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
+++ b/codegen/src/main/scala/json/schema/codegen/ScalaGenerator.scala
@@ -249,9 +249,11 @@ trait ScalaGenerator extends CodeGenerator with ScalaNaming {
 
   def genCodecDateTime(): String =
     s"""
+    val IsoOffsetDateTimeWithMilliseconds = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+
     implicit def DateTimeCodec: CodecJson[java.time.OffsetDateTime] =
       CodecJson.derived(
-        EncodeJson(v => jString(v.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.of("UTC"))))),
+        EncodeJson(v => jString(v.format(IsoOffsetDateTimeWithMilliseconds.withZone(ZoneId.of("UTC"))))),
         StringDecodeJson.flatMap { dateTimeString =>
           DecodeJson(
             j => {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.18-SNAPSHOT"
+version in ThisBuild := "0.8.18"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.18"
+version in ThisBuild := "0.8.19-SNAPSHOT"


### PR DESCRIPTION
Related to issue: [GMV-413](https://tundradotcom.atlassian.net/browse/GMV-413)

When serializing OffsetDateTime with the formatter:
`DateTimeFormatter.ISO_OFFSET_DATE_TIME`

it would by default remove the trailing zeros on the milliseconds.
The problem is that on the API we expect to have the timeDate with
milliseconds precision.